### PR TITLE
[13.0][password_security] : Multiple corrections to add missing translations in the fr.po file

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Password Security",
     "summary": "Allow admin to set password security requirements.",
-    "version": "13.0.1.0.0",
+    "version": "13.0.2.0.0",
     "author": "LasLabs, "
     "Kaushal Prajapati, "
     "Tecnativa, "

--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -13,13 +13,14 @@
     "Omar Nasr, "
     "Odoo Community Association (OCA)",
     "category": "Base",
-    "depends": ["auth_signup", "auth_password_policy_signup"],
+    "depends": ["auth_signup", "auth_password_policy_signup", "auth_password_policy"],
     "website": "https://github.com/OCA/server-auth",
     "external_dependencies": {"python": ["zxcvbn"]},
     "license": "LGPL-3",
     "data": [
         "views/password_security.xml",
         "views/res_config_settings_views.xml",
+        "views/signup_fields_templates.xml",
         "security/ir.model.access.csv",
         "security/res_users_pass_history.xml",
     ],

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -25,16 +25,17 @@ class PasswordSecuritySession(Session):
 
 class PasswordSecurityHome(AuthSignupHome):
     def get_auth_signup_config(self):
-        super(PasswordSecurityHome, self).get_auth_signup_config()
+        config = super(PasswordSecurityHome, self).get_auth_signup_config()
         company = request.env.company
-        return {
+        config.update({
             "password_length": company.password_length,
             "password_lower": company.password_lower,
             "password_upper": company.password_upper,
             "password_numeric": company.password_numeric,
             "password_special": company.password_special,
             "password_estimate": company.password_estimate,
-        }
+        })
+        return config
 
     def do_signup(self, qcontext):
         password = qcontext.get("password")

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -24,6 +24,18 @@ class PasswordSecuritySession(Session):
 
 
 class PasswordSecurityHome(AuthSignupHome):
+    def get_auth_signup_config(self):
+        super(PasswordSecurityHome, self).get_auth_signup_config()
+        company = request.env.company
+        return {
+            "password_length": company.password_length,
+            "password_lower": company.password_lower,
+            "password_upper": company.password_upper,
+            "password_numeric": company.password_numeric,
+            "password_special": company.password_special,
+            "password_estimate": company.password_estimate,
+        }
+
     def do_signup(self, qcontext):
         password = qcontext.get("password")
         user_id = request.env.user

--- a/password_security/i18n/fr.po
+++ b/password_security/i18n/fr.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-22 01:12+0000\n"
-"PO-Revision-Date: 2022-10-10 13:07+0000\n"
-"Last-Translator: Logan Gônet <logan.gonet@horanet.com>\n"
-"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
-"Language: fr\n"
+"POT-Creation-Date: 2022-10-20 14:24+0000\n"
+"PO-Revision-Date: 2022-10-20 14:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -35,7 +34,8 @@ msgstr "Ajoutez un ou deux mots. Les mots inhabituels sont mieux."
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "All-uppercase is almost as easy to guess as all-lowercase."
-msgstr "Les majuscules sont presque aussi faciles à deviner que les minuscules."
+msgstr ""
+"Les majuscules sont presque aussi faciles à deviner que les minuscules."
 
 #. module: password_security
 #: model:ir.model.fields,help:password_security.field_res_company__password_minimum
@@ -177,6 +177,11 @@ msgid "Estimation"
 msgstr "Estimation"
 
 #. module: password_security
+#: model:ir.model,name:password_security.model_ir_http
+msgid "HTTP Routing"
+msgstr "Routage HTTP"
+
+#. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_history
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_history
 msgid "History"
@@ -231,7 +236,8 @@ msgstr "Des lettres minuscules (au moins %(password_lower_config)d caractère)"
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Lowercase letter (At least %(password_lower_config)d characters)"
-msgstr "Des lettres minuscules (au moins %(password_lower_config)d caractères)"
+msgstr ""
+"Des lettres minuscules (au moins %(password_lower_config)d caractères)"
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_minimum
@@ -303,14 +309,16 @@ msgstr "Des chiffres"
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Numeric digit (At least %(password_numeric_config)d character)"
-msgstr "Des caractères numériques (au moins %(password_numeric_config)d caractère)"
+msgstr ""
+"Des caractères numériques (au moins %(password_numeric_config)d caractère)"
 
 #. module: password_security
 #: code:addons/password_security/models/res_users.py:0
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Numeric digit (At least %(password_numeric_config)d characters)"
-msgstr "Des caractères numériques (au moins %(password_numeric_config)d caractères)"
+msgstr ""
+"Des caractères numériques (au moins %(password_numeric_config)d caractères)"
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_users__password_history_ids
@@ -445,7 +453,8 @@ msgstr "Des caractères spéciaux"
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Special character (At least %(password_special_config)d character)"
-msgstr "Des caractères spéciaux (au moins %(password_special_config)d caractère)"
+msgstr ""
+"Des caractères spéciaux (au moins %(password_special_config)d caractère)"
 
 #. module: password_security
 #: code:addons/password_security/models/res_users.py:0
@@ -467,7 +476,7 @@ msgstr "Les lignes droites des touches du clavier sont faciles à deviner."
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Suggestion(s) :"
-msgstr "Suggestion(s) :"
+msgstr ""
 
 #. module: password_security
 #: code:addons/password_security/models/res_company.py:0
@@ -561,51 +570,43 @@ msgstr "Utilisateurs"
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:35
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:35
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
-msgid "at least "
-msgstr "au moins "
+msgid "at least %d characters"
+msgstr "au moins %d caractères"
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:45
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:45
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
-msgid " lower case characters"
-msgstr " caractères minuscules"
+msgid "at least %d lower case characters"
+msgstr "au moins %d caractères minuscules"
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:39
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:39
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
-msgid " characters"
-msgstr " caractères"
+msgid "at least %d numeric characters"
+msgstr "au moins %d caractères numériques"
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:51
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:51
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
-msgid " upper case characters"
-msgstr " caractères majuscules"
+msgid "at least %d special characters"
+msgstr "au moins %d caractères spéciaux"
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:57
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:57
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
-msgid " numeric characters"
-msgstr " caractères numériques"
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:63
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:63
-#, python-format
-msgid " special characters"
-msgstr " caractères spéciaux"
+msgid "at least %d upper case characters"
+msgstr "au moins %d caractères majuscules"
 
 #. module: password_security
 #: model_terms:ir.ui.view,arch_db:password_security.res_config_settings_view_form

--- a/password_security/i18n/fr.po
+++ b/password_security/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-20 14:24+0000\n"
-"PO-Revision-Date: 2022-10-20 14:24+0000\n"
+"POT-Creation-Date: 2022-10-28 10:36+0000\n"
+"PO-Revision-Date: 2022-10-28 10:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -20,7 +20,7 @@ msgstr ""
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "A word by itself is easy to guess."
-msgstr "Un mot est facile à deviner."
+msgstr "Un mot seul est facile à deviner."
 
 #. module: password_security
 #: code:addons/password_security/models/res_users.py:0
@@ -34,8 +34,7 @@ msgstr "Ajoutez un ou deux mots. Les mots inhabituels sont mieux."
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "All-uppercase is almost as easy to guess as all-lowercase."
-msgstr ""
-"Les majuscules sont presque aussi faciles à deviner que les minuscules."
+msgstr "Tout mettre en majuscule est presque aussi facile à deviner que tout en minuscule"
 
 #. module: password_security
 #: model:ir.model.fields,help:password_security.field_res_company__password_minimum
@@ -64,7 +63,7 @@ msgstr "Évitez les années récentes."
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Avoid repeated words and characters."
-msgstr "Évitez les mots et les caractères répétés."
+msgstr "Évitez les mots et les caractères répétitifs."
 
 #. module: password_security
 #: code:addons/password_security/models/res_users.py:0
@@ -105,7 +104,7 @@ msgstr "Longueur minimale"
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Common names and surnames are easy to guess."
-msgstr "Les noms communs et les noms de famille sont faciles à deviner."
+msgstr "Les noms et prénoms communs sont faciles à deviner."
 
 #. module: password_security
 #: model:ir.model,name:password_security.model_res_company
@@ -573,8 +572,24 @@ msgstr "Utilisateurs"
 #: code:addons/password_security/static/src/js/password_gauge.js:0
 #: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
+msgid "at least %d character"
+msgstr "au moins %d caractère"
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
 msgid "at least %d characters"
 msgstr "au moins %d caractères"
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
+msgid "at least %d lower case character"
+msgstr "au moins %d caractère minuscule"
 
 #. module: password_security
 #. openerp-web
@@ -589,6 +604,14 @@ msgstr "au moins %d caractères minuscules"
 #: code:addons/password_security/static/src/js/password_gauge.js:0
 #: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
+msgid "at least %d numeric character"
+msgstr "au moins %d caractère numérique"
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
 msgid "at least %d numeric characters"
 msgstr "au moins %d caractères numériques"
 
@@ -597,8 +620,24 @@ msgstr "au moins %d caractères numériques"
 #: code:addons/password_security/static/src/js/password_gauge.js:0
 #: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
+msgid "at least %d special character"
+msgstr "au moins %d caractère spécial"
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
 msgid "at least %d special characters"
 msgstr "au moins %d caractères spéciaux"
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
+msgid "at least %d upper case character"
+msgstr "au moins %d caractère majuscule"
 
 #. module: password_security
 #. openerp-web

--- a/password_security/i18n/fr.po
+++ b/password_security/i18n/fr.po
@@ -1,23 +1,41 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * password_security
+# 	* password_security
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2016
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-06-22 01:12+0000\n"
-"PO-Revision-Date: 2021-07-12 10:48+0000\n"
+"PO-Revision-Date: 2022-10-10 13:07+0000\n"
 "Last-Translator: Logan Gônet <logan.gonet@horanet.com>\n"
 "Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Plural-Forms: \n"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "A word by itself is easy to guess."
+msgstr "Un mot est facile à deviner."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Add another word or two. Uncommon words are better."
+msgstr "Ajoutez un ou deux mots. Les mots inhabituels sont mieux."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "All-uppercase is almost as easy to guess as all-lowercase."
+msgstr "Les majuscules sont presque aussi faciles à deviner que les minuscules."
 
 #. module: password_security
 #: model:ir.model.fields,help:password_security.field_res_company__password_minimum
@@ -28,16 +46,66 @@ msgstr ""
 "nouveau son mot de passe"
 
 #. module: password_security
-#: code:addons/password_security/models/res_users.py:200
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid dates and years that are associated with you."
+msgstr "Évitez les dates et les années qui vous sont associées."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid recent years."
+msgstr "Évitez les années récentes."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid repeated words and characters."
+msgstr "Évitez les mots et les caractères répétés."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid sequences."
+msgstr "Évitez les séquences."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid years that are associated with you."
+msgstr "Évitez les années qui vous sont associées."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Cannot use the most recent %d passwords"
 msgstr "Interdire l'utilisation des %d mots de passe les plus récents"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Capitalization doesn't help very much."
+msgstr "La capitalisation n’aide pas beaucoup."
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_length
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_length
 msgid "Characters"
 msgstr "Longueur minimale"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Common names and surnames are easy to guess."
+msgstr "Les noms communs et les noms de famille sont faciles à deviner."
 
 #. module: password_security
 #: model:ir.model,name:password_security.model_res_company
@@ -65,6 +133,13 @@ msgid "Date"
 msgstr "Date"
 
 #. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Dates are often easy to guess."
+msgstr "Les dates sont souvent faciles à deviner."
+
+#. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_expiration
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_expiration
 msgid "Days"
@@ -82,8 +157,8 @@ msgid ""
 "Disallow reuse of this many previous passwords - use negative number for "
 "infinite, or 0 to disable"
 msgstr ""
-"Empêche la réutilisation de plusieurs mots de passe précédents - Utilisez un "
-"nombre négatif pour l'infini, ou 0 pour désactiver cette fonctionnalité"
+"Empêche la réutilisation de plusieurs mots de passe précédents - Utilisez un"
+" nombre négatif pour l'infini, ou 0 pour désactiver cette fonctionnalité"
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_users_pass_history__display_name
@@ -145,6 +220,20 @@ msgid "Lowercase"
 msgstr "Des lettres minuscules"
 
 #. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Lowercase letter (At least %(password_lower_config)d character)"
+msgstr "Des lettres minuscules (au moins %(password_lower_config)d caractère)"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Lowercase letter (At least %(password_lower_config)d characters)"
+msgstr "Des lettres minuscules (au moins %(password_lower_config)d caractères)"
+
+#. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_minimum
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_minimum
 msgid "Minimum Hours"
@@ -175,7 +264,7 @@ msgstr "Nombre minimum de caractères spéciaux"
 #. module: password_security
 #: model_terms:ir.ui.view,arch_db:password_security.res_config_settings_view_form
 msgid "Minimum number of strength estimation"
-msgstr ""
+msgstr "Nombre minimal de l'estimation de la force"
 
 #. module: password_security
 #: model_terms:ir.ui.view,arch_db:password_security.res_config_settings_view_form
@@ -183,16 +272,45 @@ msgid "Minimum number of uppercase characters"
 msgstr "Nombre minimum de caractères majuscules"
 
 #. module: password_security
-#: code:addons/password_security/models/res_users.py:107
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Must contain the following:"
 msgstr "Doit contenir :"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Names and surnames by themselves are easy to guess."
+msgstr "Les noms et prénoms sont faciles à deviner"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "No need for symbols, digits, or uppercase letters."
+msgstr "Pas besoin de symboles, chiffres ou majuscules"
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_numeric
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_numeric
 msgid "Numeric"
 msgstr "Des chiffres"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Numeric digit (At least %(password_numeric_config)d character)"
+msgstr "Des caractères numériques (au moins %(password_numeric_config)d caractère)"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Numeric digit (At least %(password_numeric_config)d characters)"
+msgstr "Des caractères numériques (au moins %(password_numeric_config)d caractères)"
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_users__password_history_ids
@@ -210,7 +328,15 @@ msgid "Password expires in"
 msgstr "Le mot de passe expire dans"
 
 #. module: password_security
-#: code:addons/password_security/models/res_users.py:177
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Password must be %d characters or more."
+msgstr "Le mot de passe doit compter %d caractères ou plus."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid ""
 "Passwords can only be reset every %d hour(s). Please contact an "
@@ -218,6 +344,39 @@ msgid ""
 msgstr ""
 "Les mots de passe peuvent seulement être changé toutes les %d heure(s). "
 "Veuillez contacter votre administrateur pour obtenir de l'aide."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid ""
+"Predictable substitutions like '@' instead of 'a' don't help very much."
+msgstr ""
+"Des substitutions prévisibles comme '@' au lieu de 'a' n’aident pas "
+"beaucoup."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Recent years are easy to guess."
+msgstr "Les années récentes sont faciles à deviner."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Repeats like \"aaa\" are easy to guess."
+msgstr "Les répétitions comme \"aaa\" sont faciles à deviner."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Repeats like \"abcabcabc\" are only slightly harder  to guess than \"abc\"."
+msgstr ""
+"Les répétitions comme \"abcabcabc\" ne sont que légèrement plus difficiles à"
+" deviner que \"abc\"."
 
 #. module: password_security
 #: model:ir.model.fields,help:password_security.field_res_company__password_lower
@@ -255,22 +414,130 @@ msgid "Res Users Password History"
 msgstr "Historique des mots de passe des utilisateurs"
 
 #. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Reversed words aren't much harder to guess."
+msgstr "Les mots inversés ne sont pas plus difficiles à deviner."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Sequences like \"abc\" or \"6543\" are easy to guess."
+msgstr "Les séquences comme \"abc\" ou \"6543\" sont faciles à deviner."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Short keyboard patterns are easy to guess."
+msgstr "Les motifs de clavier courts sont faciles à deviner."
+
+#. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_special
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_special
 msgid "Special"
 msgstr "Des caractères spéciaux"
 
 #. module: password_security
-#: code:addons/password_security/models/res_company.py:62
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Special character (At least %(password_special_config)d character)"
+msgstr "Des caractères spéciaux (au moins %(password_special_config)d caractère)"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Special character (At least %(password_special_config)d characters)"
+msgstr ""
+"Des caractères spéciaux (au moins %(password_special_config)d caractères)"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Straight rows of keys are easy to guess."
+msgstr "Les lignes droites des touches du clavier sont faciles à deviner."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Suggestion(s) :"
+msgstr "Suggestion(s) :"
+
+#. module: password_security
+#: code:addons/password_security/models/res_company.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_company.py:0
 #, python-format
 msgid "The estimation must be between 0 and 4."
 msgstr "L'estimation doit être comprise entre 0 et 4."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "This is a top-10 common password."
+msgstr "C’est un des 10 mots de passe les plus courants."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "This is a top-100 common password."
+msgstr "C’est un des 100 mots de passe les plus courants."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "This is a very common password."
+msgstr "C’est un mot de passe très courant."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "This is similar to a commonly used password."
+msgstr "Ceci est similaire à un mot de passe couramment utilisé."
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_upper
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_upper
 msgid "Uppercase"
 msgstr "Des lettres majuscules"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Uppercase letter (At least %(password_upper_config)d character)"
+msgstr "Des lettres majuscules (au moins %(password_upper_config)d caractère)"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Uppercase letter (At least %(password_upper_config)d characters)"
+msgstr ""
+"Des lettres majuscules (au moins %(password_upper_config)d caractères)"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Use a few words, avoid common phrases."
+msgstr "Utilisez quelques mots, évitez les phrases courantes."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Use a longer keyboard pattern with more turns."
+msgstr "Utilisez un motif clavier plus long avec plus de tournures."
 
 #. module: password_security
 #: model_terms:ir.ui.view,arch_db:password_security.res_config_settings_view_form
@@ -294,38 +561,51 @@ msgstr "Utilisateurs"
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:40
+#: code:addons/password_security/static/src/js/password_gauge.js:35
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:35
 #, python-format
-msgid "at least %d characters"
-msgstr "au moins %d caractères"
+msgid "at least "
+msgstr "au moins "
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:49
+#: code:addons/password_security/static/src/js/password_gauge.js:45
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:45
 #, python-format
-msgid "at least %d lower case characters"
-msgstr "au moins %d caractères minuscules"
+msgid " lower case characters"
+msgstr " caractères minuscules"
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:67
+#: code:addons/password_security/static/src/js/password_gauge.js:39
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:39
 #, python-format
-msgid "at least %d numeric characters"
-msgstr "au moins %d caractères numériques"
+msgid " characters"
+msgstr " caractères"
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:76
+#: code:addons/password_security/static/src/js/password_gauge.js:51
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:51
 #, python-format
-msgid "at least %d special characters"
-msgstr "au moins %d caractères spéciaux"
+msgid " upper case characters"
+msgstr " caractères majuscules"
 
 #. module: password_security
 #. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:58
+#: code:addons/password_security/static/src/js/password_gauge.js:57
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:57
 #, python-format
-msgid "at least %d upper case characters"
-msgstr "au moins %d caractères majuscules"
+msgid " numeric characters"
+msgstr " caractères numériques"
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:63
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:63
+#, python-format
+msgid " special characters"
+msgstr " caractères spéciaux"
 
 #. module: password_security
 #: model_terms:ir.ui.view,arch_db:password_security.res_config_settings_view_form
@@ -341,27 +621,3 @@ msgstr "heures."
 #: model_terms:ir.ui.view,arch_db:password_security.res_config_settings_view_form
 msgid "previous passwords."
 msgstr "mots de passe précédents."
-
-#~ msgid "Extra"
-#~ msgstr "Options supplémentaires"
-
-#~ msgid "Required Characters"
-#~ msgstr "Doit contenir"
-
-#~ msgid "Timings"
-#~ msgstr "Durées"
-
-#~ msgid "Lowercase letter"
-#~ msgstr "Lettre minuscule"
-
-#~ msgid "Numeric digit"
-#~ msgstr "Nombre"
-
-#~ msgid "Password must be %d characters or more."
-#~ msgstr "Le mot de passe doit contenir %d caractères ou plus."
-
-#~ msgid "Special character"
-#~ msgstr "Caractère spécial"
-
-#~ msgid "Uppercase letter"
-#~ msgstr "Lettre majuscule"

--- a/password_security/i18n/password_security.pot
+++ b/password_security/i18n/password_security.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-10 12:59+0000\n"
-"PO-Revision-Date: 2022-10-10 12:59+0000\n"
+"POT-Creation-Date: 2022-10-20 14:23+0000\n"
+"PO-Revision-Date: 2022-10-20 14:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,11 @@ msgid "Estimation"
 msgstr ""
 
 #. module: password_security
+#: model:ir.model,name:password_security.model_ir_http
+msgid "HTTP Routing"
+msgstr ""
+
+#. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_history
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_history
 msgid "History"
@@ -226,54 +231,6 @@ msgstr ""
 #: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Lowercase letter (At least %(password_lower_config)d characters)"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:45
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:45
-#, python-format
-msgid " lower case characters"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:39
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:39
-#, python-format
-msgid " characters"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:51
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:51
-#, python-format
-msgid " upper case characters"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:57
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:57
-#, python-format
-msgid " numeric characters"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:63
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:63
-#, python-format
-msgid " special characters"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:35
-#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:35
-#, python-format
-msgid "at least "
 msgstr ""
 
 #. module: password_security
@@ -592,6 +549,46 @@ msgstr ""
 #. module: password_security
 #: model:ir.model,name:password_security.model_res_users
 msgid "Users"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
+msgid "at least %d characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
+msgid "at least %d lower case characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
+msgid "at least %d numeric characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
+msgid "at least %d special characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
+msgid "at least %d upper case characters"
 msgstr ""
 
 #. module: password_security

--- a/password_security/i18n/password_security.pot
+++ b/password_security/i18n/password_security.pot
@@ -6,12 +6,35 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-10-10 12:59+0000\n"
+"PO-Revision-Date: 2022-10-10 12:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "A word by itself is easy to guess."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Add another word or two. Uncommon words are better."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "All-uppercase is almost as easy to guess as all-lowercase."
+msgstr ""
 
 #. module: password_security
 #: model:ir.model.fields,help:password_security.field_res_company__password_minimum
@@ -21,14 +44,64 @@ msgstr ""
 
 #. module: password_security
 #: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid dates and years that are associated with you."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid recent years."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid repeated words and characters."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid sequences."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Avoid years that are associated with you."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Cannot use the most recent %d passwords"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Capitalization doesn't help very much."
 msgstr ""
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_length
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_length
 msgid "Characters"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Common names and surnames are easy to guess."
 msgstr ""
 
 #. module: password_security
@@ -54,6 +127,13 @@ msgstr ""
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_users_pass_history__date
 msgid "Date"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Dates are often easy to guess."
 msgstr ""
 
 #. module: password_security
@@ -135,6 +215,68 @@ msgid "Lowercase"
 msgstr ""
 
 #. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Lowercase letter (At least %(password_lower_config)d character)"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Lowercase letter (At least %(password_lower_config)d characters)"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:45
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:45
+#, python-format
+msgid " lower case characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:39
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:39
+#, python-format
+msgid " characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:51
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:51
+#, python-format
+msgid " upper case characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:57
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:57
+#, python-format
+msgid " numeric characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:63
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:63
+#, python-format
+msgid " special characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:35
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:35
+#, python-format
+msgid "at least "
+msgstr ""
+
+#. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_minimum
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_minimum
 msgid "Minimum Hours"
@@ -174,14 +316,43 @@ msgstr ""
 
 #. module: password_security
 #: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid "Must contain the following:"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Names and surnames by themselves are easy to guess."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "No need for symbols, digits, or uppercase letters."
 msgstr ""
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_numeric
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_numeric
 msgid "Numeric"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Numeric digit (At least %(password_numeric_config)d character)"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Numeric digit (At least %(password_numeric_config)d characters)"
 msgstr ""
 
 #. module: password_security
@@ -201,10 +372,47 @@ msgstr ""
 
 #. module: password_security
 #: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Password must be %d characters or more."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
 #, python-format
 msgid ""
 "Passwords can only be reset every %d hour(s). Please contact an "
 "administrator for assistance."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid ""
+"Predictable substitutions like '@' instead of 'a' don't help very much."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Recent years are easy to guess."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Repeats like \"aaa\" are easy to guess."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Repeats like \"abcabcabc\" are only slightly harder  to guess than \"abc\"."
 msgstr ""
 
 #. module: password_security
@@ -243,21 +451,127 @@ msgid "Res Users Password History"
 msgstr ""
 
 #. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Reversed words aren't much harder to guess."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Sequences like \"abc\" or \"6543\" are easy to guess."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Short keyboard patterns are easy to guess."
+msgstr ""
+
+#. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_special
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_special
 msgid "Special"
 msgstr ""
 
 #. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Special character (At least %(password_special_config)d character)"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Special character (At least %(password_special_config)d characters)"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Straight rows of keys are easy to guess."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Suggestion(s) :"
+msgstr ""
+
+#. module: password_security
 #: code:addons/password_security/models/res_company.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_company.py:0
 #, python-format
 msgid "The estimation must be between 0 and 4."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "This is a top-10 common password."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "This is a top-100 common password."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "This is a very common password."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "This is similar to a commonly used password."
 msgstr ""
 
 #. module: password_security
 #: model:ir.model.fields,field_description:password_security.field_res_company__password_upper
 #: model:ir.model.fields,field_description:password_security.field_res_config_settings__password_upper
 msgid "Uppercase"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Uppercase letter (At least %(password_upper_config)d character)"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Uppercase letter (At least %(password_upper_config)d characters)"
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Use a few words, avoid common phrases."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:0
+#: code:addons/setup/password_security/odoo/addons/password_security/models/res_users.py:0
+#, python-format
+msgid "Use a longer keyboard pattern with more turns."
 msgstr ""
 
 #. module: password_security
@@ -278,41 +592,6 @@ msgstr ""
 #. module: password_security
 #: model:ir.model,name:password_security.model_res_users
 msgid "Users"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:0
-#, python-format
-msgid "at least %d characters"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:0
-#, python-format
-msgid "at least %d lower case characters"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:0
-#, python-format
-msgid "at least %d numeric characters"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:0
-#, python-format
-msgid "at least %d special characters"
-msgstr ""
-
-#. module: password_security
-#. openerp-web
-#: code:addons/password_security/static/src/js/password_gauge.js:0
-#, python-format
-msgid "at least %d upper case characters"
 msgstr ""
 
 #. module: password_security

--- a/password_security/i18n/password_security.pot
+++ b/password_security/i18n/password_security.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-20 14:23+0000\n"
-"PO-Revision-Date: 2022-10-20 14:23+0000\n"
+"POT-Creation-Date: 2022-10-28 10:35+0000\n"
+"PO-Revision-Date: 2022-10-28 10:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -556,7 +556,23 @@ msgstr ""
 #: code:addons/password_security/static/src/js/password_gauge.js:0
 #: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
+msgid "at least %d character"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
 msgid "at least %d characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
+msgid "at least %d lower case character"
 msgstr ""
 
 #. module: password_security
@@ -572,6 +588,14 @@ msgstr ""
 #: code:addons/password_security/static/src/js/password_gauge.js:0
 #: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
+msgid "at least %d numeric character"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
 msgid "at least %d numeric characters"
 msgstr ""
 
@@ -580,7 +604,23 @@ msgstr ""
 #: code:addons/password_security/static/src/js/password_gauge.js:0
 #: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
 #, python-format
+msgid "at least %d special character"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
 msgid "at least %d special characters"
+msgstr ""
+
+#. module: password_security
+#. openerp-web
+#: code:addons/password_security/static/src/js/password_gauge.js:0
+#: code:addons/setup/password_security/odoo/addons/password_security/static/src/js/password_gauge.js:0
+#, python-format
+msgid "at least %d upper case character"
 msgstr ""
 
 #. module: password_security

--- a/password_security/models/__init__.py
+++ b/password_security/models/__init__.py
@@ -1,4 +1,10 @@
 # Copyright 2015 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from . import res_company, res_config_settings, res_users, res_users_pass_history
+from . import (
+    inherit_ir_http,
+    res_company,
+    res_config_settings,
+    res_users,
+    res_users_pass_history,
+)

--- a/password_security/models/inherit_ir_http.py
+++ b/password_security/models/inherit_ir_http.py
@@ -1,0 +1,42 @@
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    """Surcharge pour ajouter les traductions du module en front."""
+
+    # region Private attributes
+    _inherit = "ir.http"
+
+    # endregion
+
+    # region Default methods
+    # endregion
+
+    # region Fields declaration
+    # endregion
+
+    # region Fields method
+    # endregion
+
+    # region Constraints and Onchange
+    # endregion
+
+    # region CRUD (overrides)
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        """Add the module name to the list of module that have frontend translation.
+
+        override :meth:
+        odoo.addons.http_routing.models.ir_http._get_translation_frontend_modules_name
+        """
+        # noinspection PyProtectedMember
+        mods = super(IrHttp, cls)._get_translation_frontend_modules_name()
+        return mods + ["password_security"]
+
+    # endregion
+
+    # region Actions
+    # endregion
+
+    # region Model methods
+    # endregion

--- a/password_security/models/inherit_ir_http.py
+++ b/password_security/models/inherit_ir_http.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class IrHttp(models.AbstractModel):
-    """Surcharge pour ajouter les traductions du module en front."""
+    """Overload to add module translations in front."""
 
     # region Private attributes
     _inherit = "ir.http"

--- a/password_security/models/inherit_ir_http.py
+++ b/password_security/models/inherit_ir_http.py
@@ -31,7 +31,7 @@ class IrHttp(models.AbstractModel):
         """
         # noinspection PyProtectedMember
         mods = super(IrHttp, cls)._get_translation_frontend_modules_name()
-        return mods + ["password_security"]
+        return mods + ["auth_password_policy", "password_security"]
 
     # endregion
 

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -281,7 +281,7 @@ class ResUsers(models.Model):
             suggestions = estimation["feedback"]["suggestions"]
             full_msg = estimation["feedback"]["warning"] + "\n"
             if suggestions:
-                full_msg += _("Suggestion(s) :\n")
+                full_msg += _("Suggestion(s) :") + "\n"
                 for suggestion in suggestions:
                     full_msg += suggestion
             raise PassError(full_msg)

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -81,74 +81,89 @@ class ResUsers(models.Model):
     @api.model
     def get_estimation(self, password):
         msg_translate = {
-            "Use a few words, avoid common phrases.":
-                _('Use a few words, avoid common phrases.'),
-            "No need for symbols, digits, or uppercase letters.":
-                _("No need for symbols, digits, or uppercase letters."),
-            'Add another word or two. Uncommon words are better.':
-                _('Add another word or two. Uncommon words are better.'),
-            'Straight rows of keys are easy to guess.':
-                _('Straight rows of keys are easy to guess.'),
-            'Short keyboard patterns are easy to guess.':
-                _('Short keyboard patterns are easy to guess.'),
-            'Use a longer keyboard pattern with more turns.':
-                _('Use a longer keyboard pattern with more turns.'),
-            'Repeats like "aaa" are easy to guess.':
-                _('Repeats like "aaa" are easy to guess.'),
-            'Repeats like "abcabcabc" are only slightly harder to guess than "abc".':
-                _('Repeats like "abcabcabc" are only slightly harder  to guess than '
-                  '"abc".'),
-            'Avoid repeated words and characters.':
-                _('Avoid repeated words and characters.'),
-            'Sequences like "abc" or "6543" are easy to guess.':
-                _('Sequences like "abc" or "6543" are easy to guess.'),
-            'Avoid sequences.':
-                _('Avoid sequences.'),
-            "Recent years are easy to guess.":
-                _("Recent years are easy to guess."),
-            'Avoid recent years.':
-                _('Avoid recent years.'),
-            'Avoid years that are associated with you.':
-                _('Avoid years that are associated with you.'),
-            "Dates are often easy to guess.":
-                _("Dates are often easy to guess."),
-            'Avoid dates and years that are associated with you.':
-                _('Avoid dates and years that are associated with you.'),
-            'This is a top-10 common password.':
-                _('This is a top-10 common password.'),
-            'This is a top-100 common password.':
-                _('This is a top-100 common password.'),
-            'This is a very common password.':
-                _('This is a very common password.'),
-            'This is similar to a commonly used password.':
-                _('This is similar to a commonly used password.'),
-            'A word by itself is easy to guess.':
-                _('A word by itself is easy to guess.'),
-            "Names and surnames by themselves are easy to guess.":
-                _("Names and surnames by themselves are easy to guess."),
-            'Common names and surnames are easy to guess.':
-                _('Common names and surnames are easy to guess.'),
-            "Capitalization doesn't help very much.":
-                _("Capitalization doesn't help very much."),
-            "All-uppercase is almost as easy to guess as all-lowercase.":
-                _("All-uppercase is almost as easy to guess as all-lowercase."),
-            "Reversed words aren't much harder to guess.":
-                _("Reversed words aren't much harder to guess."),
-            "Predictable substitutions like '@' instead of 'a' don't help very much.":
-                _("Predictable substitutions like '@' instead of 'a' don't help very "
-                  "much.")
+            "Use a few words, avoid common phrases.": _(
+                "Use a few words, avoid common phrases."
+            ),
+            "No need for symbols, digits, or uppercase letters.": _(
+                "No need for symbols, digits, or uppercase letters."
+            ),
+            "Add another word or two. Uncommon words are better.": _(
+                "Add another word or two. Uncommon words are better."
+            ),
+            "Straight rows of keys are easy to guess.": _(
+                "Straight rows of keys are easy to guess."
+            ),
+            "Short keyboard patterns are easy to guess.": _(
+                "Short keyboard patterns are easy to guess."
+            ),
+            "Use a longer keyboard pattern with more turns.": _(
+                "Use a longer keyboard pattern with more turns."
+            ),
+            'Repeats like "aaa" are easy to guess.': _(
+                'Repeats like "aaa" are easy to guess.'
+            ),
+            'Repeats like "abcabcabc" are only slightly harder to guess than "abc".': _(
+                'Repeats like "abcabcabc" are only slightly harder  to guess than '
+                '"abc".'
+            ),
+            "Avoid repeated words and characters.": _(
+                "Avoid repeated words and characters."
+            ),
+            'Sequences like "abc" or "6543" are easy to guess.': _(
+                'Sequences like "abc" or "6543" are easy to guess.'
+            ),
+            "Avoid sequences.": _("Avoid sequences."),
+            "Recent years are easy to guess.": _("Recent years are easy to guess."),
+            "Avoid recent years.": _("Avoid recent years."),
+            "Avoid years that are associated with you.": _(
+                "Avoid years that are associated with you."
+            ),
+            "Dates are often easy to guess.": _("Dates are often easy to guess."),
+            "Avoid dates and years that are associated with you.": _(
+                "Avoid dates and years that are associated with you."
+            ),
+            "This is a top-10 common password.": _("This is a top-10 common password."),
+            "This is a top-100 common password.": _(
+                "This is a top-100 common password."
+            ),
+            "This is a very common password.": _("This is a very common password."),
+            "This is similar to a commonly used password.": _(
+                "This is similar to a commonly used password."
+            ),
+            "A word by itself is easy to guess.": _(
+                "A word by itself is easy to guess."
+            ),
+            "Names and surnames by themselves are easy to guess.": _(
+                "Names and surnames by themselves are easy to guess."
+            ),
+            "Common names and surnames are easy to guess.": _(
+                "Common names and surnames are easy to guess."
+            ),
+            "Capitalization doesn't help very much.": _(
+                "Capitalization doesn't help very much."
+            ),
+            "All-uppercase is almost as easy to guess as all-lowercase.": _(
+                "All-uppercase is almost as easy to guess as all-lowercase."
+            ),
+            "Reversed words aren't much harder to guess.": _(
+                "Reversed words aren't much harder to guess."
+            ),
+            "Predictable substitutions like '@' instead of 'a' don't help very much.": _(
+                "Predictable substitutions like '@' instead of 'a' don't help very "
+                "much."
+            ),
         }
         estimation = zxcvbn.zxcvbn(password)
-        warning = estimation['feedback']['warning']
-        suggestions = estimation['feedback']['suggestions']
+        warning = estimation["feedback"]["warning"]
+        suggestions = estimation["feedback"]["suggestions"]
         if warning in msg_translate:
-            estimation['feedback']['warning'] = msg_translate[warning]
+            estimation["feedback"]["warning"] = msg_translate[warning]
         translated_suggestions = []
         for suggestion in suggestions:
             translated_suggestions.append(
-                msg_translate[suggestion] if suggestion in msg_translate else
-                suggestion)
-        estimation['feedback']['suggestions'] = translated_suggestions
+                msg_translate[suggestion] if suggestion in msg_translate else suggestion
+            )
+        estimation["feedback"]["suggestions"] = translated_suggestions
         return estimation
 
     def password_match_message(self):
@@ -158,78 +173,86 @@ class ResUsers(models.Model):
         if company_id.password_lower:
             if company_id.password_lower > 1:
                 message.append(
-                    "\n* " +
-                    _("Lowercase letter (At least %(password_lower_config)d "
-                      "characters)") % dict(
-                        password_lower_config=company_id.password_lower
+                    "\n* "
+                    + _(
+                        "Lowercase letter (At least %(password_lower_config)d "
+                        "characters)"
                     )
+                    % dict(password_lower_config=company_id.password_lower)
                 )
             else:
                 message.append(
-                    "\n* " +
-                    _("Lowercase letter (At least %(password_lower_config)d "
-                      "character)") % dict(
-                        password_lower_config=company_id.password_lower
+                    "\n* "
+                    + _(
+                        "Lowercase letter (At least %(password_lower_config)d "
+                        "character)"
                     )
+                    % dict(password_lower_config=company_id.password_lower)
                 )
         if company_id.password_upper:
             if company_id.password_upper > 1:
                 message.append(
-                    "\n* " +
-                    _("Uppercase letter (At least %(password_upper_config)d "
-                      "characters)") % dict(
-                        password_upper_config=company_id.password_upper
+                    "\n* "
+                    + _(
+                        "Uppercase letter (At least %(password_upper_config)d "
+                        "characters)"
                     )
+                    % dict(password_upper_config=company_id.password_upper)
                 )
             else:
                 message.append(
-                    "\n* " +
-                    _("Uppercase letter (At least %(password_upper_config)d "
-                      "character)") % dict(
-                        password_upper_config=company_id.password_upper
+                    "\n* "
+                    + _(
+                        "Uppercase letter (At least %(password_upper_config)d "
+                        "character)"
                     )
+                    % dict(password_upper_config=company_id.password_upper)
                 )
         if company_id.password_numeric:
             if company_id.password_numeric > 1:
                 message.append(
-                    "\n* " +
-                    _("Numeric digit (At least %(password_numeric_config)d "
-                      "characters)") % dict(
-                        password_numeric_config=company_id.password_numeric
+                    "\n* "
+                    + _(
+                        "Numeric digit (At least %(password_numeric_config)d "
+                        "characters)"
                     )
+                    % dict(password_numeric_config=company_id.password_numeric)
                 )
             else:
                 message.append(
-                    "\n* " +
-                    _("Numeric digit (At least %(password_numeric_config)d "
-                      "character)") % dict(
-                        password_numeric_config=company_id.password_numeric
+                    "\n* "
+                    + _(
+                        "Numeric digit (At least %(password_numeric_config)d "
+                        "character)"
                     )
+                    % dict(password_numeric_config=company_id.password_numeric)
                 )
             if company_id.password_special:
                 if company_id.password_special > 1:
                     message.append(
-                        "\n* " +
-                        _("Special character (At least %(password_special_config)d "
-                          "characters)") % dict(
-                            password_special_config=company_id.password_special
+                        "\n* "
+                        + _(
+                            "Special character (At least %(password_special_config)d "
+                            "characters)"
                         )
+                        % dict(password_special_config=company_id.password_special)
                     )
                 else:
                     message.append(
-                        "\n* " +
-                        _("Special character (At least %(password_special_config)d "
-                          "character)") % dict(
-                            password_special_config=company_id.password_special
+                        "\n* "
+                        + _(
+                            "Special character (At least %(password_special_config)d "
+                            "character)"
                         )
+                        % dict(password_special_config=company_id.password_special)
                     )
             if message:
                 message = [_("Must contain the following:")] + message
             if company_id.password_length:
                 message = [
-                              _(
-                                  "Password must be %d characters or more.") % company_id.password_length
-                          ] + message
+                    _("Password must be %d characters or more.")
+                    % company_id.password_length
+                ] + message
             return "\r".join(message)
 
     def _check_password(self, password):
@@ -255,8 +278,8 @@ class ResUsers(models.Model):
 
         estimation = self.get_estimation(password)
         if estimation["score"] < company_id.password_estimate:
-            suggestions = estimation['feedback']['suggestions']
-            full_msg = estimation["feedback"]["warning"] + '\n'
+            suggestions = estimation["feedback"]["suggestions"]
+            full_msg = estimation["feedback"]["warning"] + "\n"
             if suggestions:
                 full_msg += _("Suggestion(s) :\n")
                 for suggestion in suggestions:
@@ -314,7 +337,7 @@ class ResUsers(models.Model):
             if recent_passes < 0:
                 recent_passes = rec_id.password_history_ids
             else:
-                recent_passes = rec_id.password_history_ids[0: recent_passes - 1]
+                recent_passes = rec_id.password_history_ids[0 : recent_passes - 1]
             if recent_passes.filtered(
                 lambda r: crypt.verify(password, r.password_crypt)
             ):

--- a/password_security/static/src/js/password_gauge.js
+++ b/password_security/static/src/js/password_gauge.js
@@ -3,11 +3,10 @@
 odoo.define("password_security.policy", function(require) {
     "use strict";
 
-    var core = require("web.core");
-    var _t = core._t;
-    var auth_password_policy = require("auth_password_policy");
-    var Policy = auth_password_policy.Policy;
-    var zxcvbn = window.zxcvbn;
+    const core = require("web.core");
+    const _t = core._t;
+    const auth_password_policy = require("auth_password_policy");
+    const Policy = auth_password_policy.Policy;
 
     Policy.include({
         /**
@@ -32,55 +31,44 @@ odoo.define("password_security.policy", function(require) {
         },
 
         toString: function() {
-            var msgs = [];
+            const msgs = [];
+            const msg_common = _t("at least ");
 
             if (this._password_length > 0) {
-                msgs.push(
-                    _.str.sprintf(_t("at least %d characters"), this._password_length)
-                );
+                const msg_password_length =
+                    msg_common + this._password_length + _t(" characters");
+                msgs.push(msg_password_length);
             }
 
             if (this._password_lower > 0) {
-                msgs.push(
-                    _.str.sprintf(
-                        _t("at least %d lower case characters"),
-                        this._password_lower
-                    )
-                );
+                const msg_password_lower =
+                    msg_common + this._password_lower + _t(" lower case characters");
+                msgs.push(msg_password_lower);
             }
 
             if (this._password_upper > 0) {
-                msgs.push(
-                    _.str.sprintf(
-                        _t("at least %d upper case characters"),
-                        this._password_upper
-                    )
-                );
+                const msg_password_upper =
+                    msg_common + this._password_lower + _t(" upper case characters");
+                msgs.push(msg_password_upper);
             }
 
             if (this._password_numeric > 0) {
-                msgs.push(
-                    _.str.sprintf(
-                        _t("at least %d numeric characters"),
-                        this._password_numeric
-                    )
-                );
+                const msg_password_numeric =
+                    msg_common + this._password_lower + _t(" numeric characters");
+                msgs.push(msg_password_numeric);
             }
 
             if (this._password_special > 0) {
-                msgs.push(
-                    _.str.sprintf(
-                        _t("at least %d special characters"),
-                        this._password_special
-                    )
-                );
+                const msg_password_special =
+                    msg_common + this._password_lower + _t(" special characters");
+                msgs.push(msg_password_special);
             }
 
             return msgs.join(", ");
         },
 
         _calculate_password_score: function(pattern, min_count, password) {
-            var matchMinCount = new RegExp(
+            const matchMinCount = new RegExp(
                 "(.*" + pattern + ".*){" + min_count + ",}",
                 "g"
             ).exec(password);
@@ -88,8 +76,8 @@ odoo.define("password_security.policy", function(require) {
                 return 0;
             }
 
-            var count = 0;
-            var regExp = new RegExp(pattern, "g");
+            let count = 0;
+            const regExp = new RegExp(pattern, "g");
 
             while (regExp.exec(password) !== null) {
                 count++;
@@ -99,32 +87,33 @@ odoo.define("password_security.policy", function(require) {
         },
 
         _estimate: function(password) {
+            const zxcvbn = window.zxcvbn;
             return Math.min(zxcvbn(password).score / 4.0, 1.0);
         },
 
         score: function(password) {
-            var lengthscore = Math.min(password.length / this._password_length, 1.0);
-            var loverscore = this._calculate_password_score(
+            const lengthscore = Math.min(password.length / this._password_length, 1.0);
+            const loverscore = this._calculate_password_score(
                 "[a-z]",
                 this._password_lower,
                 password
             );
-            var upperscore = this._calculate_password_score(
+            const upperscore = this._calculate_password_score(
                 "[A-Z]",
                 this._password_upper,
                 password
             );
-            var numericscore = this._calculate_password_score(
+            const numericscore = this._calculate_password_score(
                 "\\d",
                 this._password_numeric,
                 password
             );
-            var specialscore = this._calculate_password_score(
+            const specialscore = this._calculate_password_score(
                 "[\\W_]",
                 this._password_special,
                 password
             );
-            var estimatescore = this._estimate(password);
+            const estimatescore = this._estimate(password);
 
             return (
                 lengthscore *
@@ -137,7 +126,7 @@ odoo.define("password_security.policy", function(require) {
         },
     });
 
-    var recommendations = {
+    const recommendations = {
         score: auth_password_policy.recommendations.score,
         policies: [
             new Policy({

--- a/password_security/static/src/js/password_gauge.js
+++ b/password_security/static/src/js/password_gauge.js
@@ -20,8 +20,6 @@ odoo.define("password_security.policy", function(require) {
          * @param {Number} [info.password_estimate=3]
          */
         init: function(info) {
-            this._super(info);
-
             this._password_length = info.password_length || 4;
             this._password_lower = info.password_lower || 1;
             this._password_upper = info.password_upper || 1;
@@ -32,36 +30,47 @@ odoo.define("password_security.policy", function(require) {
 
         toString: function() {
             const msgs = [];
-            const msg_common = _t("at least ");
 
             if (this._password_length > 0) {
-                const msg_password_length =
-                    msg_common + this._password_length + _t(" characters");
-                msgs.push(msg_password_length);
+                msgs.push(
+                    _.str.sprintf(_t("at least %d characters"), this._password_length)
+                );
             }
 
             if (this._password_lower > 0) {
-                const msg_password_lower =
-                    msg_common + this._password_lower + _t(" lower case characters");
-                msgs.push(msg_password_lower);
+                msgs.push(
+                    _.str.sprintf(
+                        _t("at least %d lower case characters"),
+                        this._password_lower
+                    )
+                );
             }
 
             if (this._password_upper > 0) {
-                const msg_password_upper =
-                    msg_common + this._password_lower + _t(" upper case characters");
-                msgs.push(msg_password_upper);
+                msgs.push(
+                    _.str.sprintf(
+                        _t("at least %d upper case characters"),
+                        this._password_upper
+                    )
+                );
             }
 
             if (this._password_numeric > 0) {
-                const msg_password_numeric =
-                    msg_common + this._password_lower + _t(" numeric characters");
-                msgs.push(msg_password_numeric);
+                msgs.push(
+                    _.str.sprintf(
+                        _t("at least %d numeric characters"),
+                        this._password_numeric
+                    )
+                );
             }
 
             if (this._password_special > 0) {
-                const msg_password_special =
-                    msg_common + this._password_lower + _t(" special characters");
-                msgs.push(msg_password_special);
+                msgs.push(
+                    _.str.sprintf(
+                        _t("at least %d special characters"),
+                        this._password_special
+                    )
+                );
             }
 
             return msgs.join(", ");
@@ -149,4 +158,23 @@ odoo.define("password_security.policy", function(require) {
     };
 
     auth_password_policy.recommendations = recommendations;
+});
+
+odoo.define("password_security.Meter", function(require) {
+    "use strict";
+
+    const session = require("web.session");
+    const PasswordMeter = require("auth_password_policy.Meter");
+
+    PasswordMeter.include({
+        init: function(parent, required, recommended) {
+            this._super(parent);
+            this._required = required;
+            this._recommended = recommended;
+        },
+        willStart: function() {
+            return Promise.all([this._super.apply(this, arguments), session.is_bound]);
+        },
+    });
+    return PasswordMeter;
 });

--- a/password_security/static/src/js/password_gauge.js
+++ b/password_security/static/src/js/password_gauge.js
@@ -20,6 +20,8 @@ odoo.define("password_security.policy", function(require) {
          * @param {Number} [info.password_estimate=3]
          */
         init: function(info) {
+            this._super(info);
+
             this._password_length = info.password_length || 4;
             this._password_lower = info.password_lower || 1;
             this._password_upper = info.password_upper || 1;
@@ -31,43 +33,75 @@ odoo.define("password_security.policy", function(require) {
         toString: function() {
             const msgs = [];
 
-            if (this._password_length > 0) {
+            if (this._password_length > 1) {
                 msgs.push(
                     _.str.sprintf(_t("at least %d characters"), this._password_length)
                 );
+            } else {
+                msgs.push(
+                    _.str.sprintf(_t("at least %d character"), this._password_length)
+                );
             }
 
-            if (this._password_lower > 0) {
+            if (this._password_lower > 1) {
                 msgs.push(
                     _.str.sprintf(
                         _t("at least %d lower case characters"),
                         this._password_lower
                     )
                 );
+            } else {
+                msgs.push(
+                    _.str.sprintf(
+                        _t("at least %d lower case character"),
+                        this._password_lower
+                    )
+                );
             }
 
-            if (this._password_upper > 0) {
+            if (this._password_upper > 1) {
                 msgs.push(
                     _.str.sprintf(
                         _t("at least %d upper case characters"),
                         this._password_upper
                     )
                 );
+            } else {
+                msgs.push(
+                    _.str.sprintf(
+                        _t("at least %d upper case character"),
+                        this._password_upper
+                    )
+                );
             }
 
-            if (this._password_numeric > 0) {
+            if (this._password_numeric > 1) {
                 msgs.push(
                     _.str.sprintf(
                         _t("at least %d numeric characters"),
                         this._password_numeric
                     )
                 );
+            } else {
+                msgs.push(
+                    _.str.sprintf(
+                        _t("at least %d numeric character"),
+                        this._password_numeric
+                    )
+                );
             }
 
-            if (this._password_special > 0) {
+            if (this._password_special > 1) {
                 msgs.push(
                     _.str.sprintf(
                         _t("at least %d special characters"),
+                        this._password_special
+                    )
+                );
+            } else {
+                msgs.push(
+                    _.str.sprintf(
+                        _t("at least %d special character"),
                         this._password_special
                     )
                 );

--- a/password_security/static/src/js/signup_policy.js
+++ b/password_security/static/src/js/signup_policy.js
@@ -1,41 +1,37 @@
-//  Copyright 2018 Modoolar <info@modoolar.com>
-//  License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
-odoo.define("password_security.signup.policy", function(require) {
+odoo.define("password_security.signup_policy", function(require) {
     "use strict";
 
-    var base = require("web_editor.base");
+    require("web.dom_ready");
     var policy = require("auth_password_policy");
-    var PasswordMeter = require("auth_password_policy.Meter");
+    var PasswordMeter = require("password_security.Meter");
 
-    base.ready().then(function() {
-        var $signupForm = $(".oe_signup_form, .oe_reset_password_form");
-        if (!$signupForm.length) {
-            return;
-        }
+    var $signupForm = $(".oe_signup_form, .oe_reset_password_form");
+    if (!$signupForm.length) {
+        return;
+    }
 
-        var $password = $signupForm.find("#password");
-        var password_length = Number($password.attr("password_length"));
-        var password_lower = Number($password.attr("password_lower"));
-        var password_upper = Number($password.attr("password_upper"));
-        var password_numeric = Number($password.attr("password_numeric"));
-        var password_special = Number($password.attr("password_special"));
-        var password_estimate = Number($password.attr("password_estimate"));
+    var $password = $signupForm.find("#password");
+    var password_length = Number($password.attr("password_length"));
+    var password_lower = Number($password.attr("password_lower"));
+    var password_upper = Number($password.attr("password_upper"));
+    var password_numeric = Number($password.attr("password_numeric"));
+    var password_special = Number($password.attr("password_special"));
+    var password_estimate = Number($password.attr("password_estimate"));
 
-        var meter = new PasswordMeter(
-            null,
-            new policy.Policy({
-                password_length: password_length,
-                password_lower: password_lower,
-                password_upper: password_upper,
-                password_numeric: password_numeric,
-                password_special: password_special,
-                password_estimate: password_estimate,
-            }),
-            policy.recommendations
-        );
-        meter.insertAfter($password);
-        $password.on("input", function() {
-            meter.update($password.val());
-        });
+    var meter = new PasswordMeter(
+        null,
+        new policy.Policy({
+            password_length: password_length,
+            password_lower: password_lower,
+            password_upper: password_upper,
+            password_numeric: password_numeric,
+            password_special: password_special,
+            password_estimate: password_estimate,
+        }),
+        policy.recommendations
+    );
+    meter.insertAfter($password);
+    $password.on("input", function() {
+        meter.update($password.val());
     });
 });

--- a/password_security/static/src/js/signup_policy.js
+++ b/password_security/static/src/js/signup_policy.js
@@ -2,21 +2,24 @@ odoo.define("password_security.signup_policy", function(require) {
     "use strict";
 
     require("web.dom_ready");
+    require("auth_password_policy_signup.policy");
     var policy = require("auth_password_policy");
     var PasswordMeter = require("password_security.Meter");
 
     var $signupForm = $(".oe_signup_form, .oe_reset_password_form");
+
     if (!$signupForm.length) {
         return;
     }
+    $signupForm.find(".field-password meter").remove();
 
     var $password = $signupForm.find("#password");
-    var password_length = Number($password.attr("password_length"));
-    var password_lower = Number($password.attr("password_lower"));
-    var password_upper = Number($password.attr("password_upper"));
-    var password_numeric = Number($password.attr("password_numeric"));
-    var password_special = Number($password.attr("password_special"));
-    var password_estimate = Number($password.attr("password_estimate"));
+    var password_length = $password.data("password_length");
+    var password_lower = $password.data("password_lower");
+    var password_upper = $password.data("password_upper");
+    var password_numeric = $password.data("password_numeric");
+    var password_special = $password.data("password_special");
+    var password_estimate = $password.data("password_estimate");
 
     var meter = new PasswordMeter(
         null,

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -81,12 +81,14 @@ class TestResUsers(TransactionCase):
             "password_numeric": self.main_comp.password_numeric,
             "password_special": self.main_comp.password_special,
         }
-        self.main_comp.write({
-            "password_lower": 2,
-            "password_upper": 2,
-            "password_numeric": 2,
-            "password_special": 2,
-        })
+        self.main_comp.write(
+            {
+                "password_lower": 2,
+                "password_upper": 2,
+                "password_numeric": 2,
+                "password_special": 2,
+            }
+        )
         with self.assertRaises(PassError):
             rec_id._check_password("password")
         self.main_comp.write(default_vals)

--- a/password_security/views/password_security.xml
+++ b/password_security/views/password_security.xml
@@ -12,11 +12,15 @@
         <xpath expr="." position="inside">
             <script
                 type="text/javascript"
+                src="/password_security/static/lib/zxcvbn/zxcvbn.min.js"
+            />
+            <script
+                type="text/javascript"
                 src="/password_security/static/src/js/password_gauge.js"
             />
             <script
                 type="text/javascript"
-                src="/password_security/static/lib/zxcvbn/zxcvbn.min.js"
+                src="/password_security/static/src/js/signup_policy.js"
             />
         </xpath>
     </template>

--- a/password_security/views/signup_fields_templates.xml
+++ b/password_security/views/signup_fields_templates.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <template
+        id="fields_security"
+        inherit_id="auth_signup.fields"
+        name="Password policy data for auth_signup"
+    >
+        <xpath expr="//input[@name='password']" position="attributes">
+            <attribute name="t-att-password_length">password_length</attribute>
+            <attribute name="t-att-password_lower">password_lower</attribute>
+            <attribute name="t-att-password_upper">password_upper</attribute>
+            <attribute name="t-att-password_numeric">password_numeric</attribute>
+            <attribute name="t-att-password_special">password_special</attribute>
+            <attribute name="t-att-password_estimate">password_estimate</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/password_security/views/signup_fields_templates.xml
+++ b/password_security/views/signup_fields_templates.xml
@@ -5,12 +5,12 @@
         name="Password policy data for auth_signup"
     >
         <xpath expr="//input[@name='password']" position="attributes">
-            <attribute name="t-att-password_length">password_length</attribute>
-            <attribute name="t-att-password_lower">password_lower</attribute>
-            <attribute name="t-att-password_upper">password_upper</attribute>
-            <attribute name="t-att-password_numeric">password_numeric</attribute>
-            <attribute name="t-att-password_special">password_special</attribute>
-            <attribute name="t-att-password_estimate">password_estimate</attribute>
+            <attribute name="t-att-data-password_length">password_length</attribute>
+            <attribute name="t-att-data-password_lower">password_lower</attribute>
+            <attribute name="t-att-data-password_upper">password_upper</attribute>
+            <attribute name="t-att-data-password_numeric">password_numeric</attribute>
+            <attribute name="t-att-data-password_special">password_special</attribute>
+            <attribute name="t-att-data-password_estimate">password_estimate</attribute>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Impacted versions: 13.0

![image](https://user-images.githubusercontent.com/102605014/198585604-3a539b19-e148-4581-9ad5-def2df5f1652.png)

When hovering over the gauge indicating the strength of the password, a message containing the recommendations is displayed (number of lower case letters, uppercase letters, etc.).
This issue allows:
- to translate this message which still remained in English 
- and take into account the password rules configured in the back office